### PR TITLE
Add necessary load() statements for rules used.

### DIFF
--- a/interface_libs/X11/BUILD.bazel
+++ b/interface_libs/X11/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_import(
     name = "x11_xcb_ifso",

--- a/interface_libs/dbus/BUILD.bazel
+++ b/interface_libs/dbus/BUILD.bazel
@@ -1,3 +1,6 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_import(
     name = "dbus_ifso",
     interface_library = "libdbus-1.ifso",

--- a/interface_libs/fontconfig/BUILD.bazel
+++ b/interface_libs/fontconfig/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_import(
     name = "fontconfig_ifso",

--- a/interface_libs/xcb/BUILD.bazel
+++ b/interface_libs/xcb/BUILD.bazel
@@ -1,3 +1,6 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_import(
     name = "xcb_randr_ifso",
     interface_library = "libxcb-randr.ifso",

--- a/interface_libs/xkbcommon/BUILD.bazel
+++ b/interface_libs/xkbcommon/BUILD.bazel
@@ -1,3 +1,6 @@
+load("@rules_cc//cc:cc_import.bzl", "cc_import")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
 cc_import(
     name = "xkbcommon_ifso",
     interface_library = "libxkbcommon.ifso",

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
 load("//:build_defs.bzl", "qt6_library")
 
 cc_binary(


### PR DESCRIPTION
Starting with bazel9, they are not imported implicitly anymore.