### PR TITLE
xcb: build xcb-util-cursor from source

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,3 +11,17 @@ bazel_dep(name = "libxcb", version = "1.17.0.bcr.2")
 bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.1.2")
 bazel_dep(name = "zlib", version = "1.3.1.bcr.6")
+
+# xcb-util-cursor 0.1.5 source — used by interface_libs/xcb to provide
+# a static replacement for the system libxcb-cursor.so.0 so the Qt xcb
+# platform plugin doesn't dlopen it from the host. Source from
+# xorg.freedesktop.org, verified by sha256.
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "xcb_util_cursor",
+    build_file = "//interface_libs/xcb:xcb_util_cursor.BUILD",
+    sha256 = "0caf99b0d60970f81ce41c7ba694e5eaaf833227bb2cbcdb2f6dc9666a663c57",
+    strip_prefix = "xcb-util-cursor-0.1.5",
+    urls = ["https://xorg.freedesktop.org/archive/individual/lib/xcb-util-cursor-0.1.5.tar.xz"],
+)

--- a/interface_libs/xcb/BUILD.bazel
+++ b/interface_libs/xcb/BUILD.bazel
@@ -67,10 +67,24 @@ cc_import(
     system_provided = True,
 )
 
-cc_import(
-    name = "xcb_cursor_ifso",
-    interface_library = "libxcb-cursor.ifso",
-    system_provided = True,
+# Headers-only target consumed by @xcb_util_cursor//:cursor (declared in
+# this module's MODULE.bazel) so xcb-util-cursor 0.1.5 source files can
+# find xcb_renderutil.h, xcb_image.h, render.h etc. without pulling in
+# the full :xcb target (which would create a circular dependency).
+cc_library(
+    name = "xcb_hdrs",
+    hdrs = glob(["xcb/*.h"]),
+    includes = ["."],
+    strip_include_prefix = ".",
+    visibility = ["//visibility:public"],
+)
+
+# xcb-util-cursor 0.1.5 built from source via @xcb_util_cursor (declared
+# in this module's MODULE.bazel). Replaces the system-provided
+# libxcb-cursor.so.0 cc_import that used to live here.
+alias(
+    name = "xcb_cursor",
+    actual = "@xcb_util_cursor//:cursor",
 )
 
 cc_import(
@@ -94,7 +108,7 @@ cc_library(
     deps = select({
         "@platforms//cpu:aarch64": [],
         "//conditions:default": [
-            ":xcb_cursor_ifso",
+            ":xcb_cursor",
             ":xcb_icccm_ifso",
             ":xcb_ifso",
             ":xcb_image_ifso",

--- a/interface_libs/xcb/BUILD.bazel
+++ b/interface_libs/xcb/BUILD.bazel
@@ -68,23 +68,19 @@ cc_import(
 )
 
 # Headers-only target consumed by @xcb_util_cursor//:cursor (declared in
-# this module's MODULE.bazel) so xcb-util-cursor 0.1.5 source files can
-# find xcb_renderutil.h, xcb_image.h, render.h etc. without pulling in
-# the full :xcb target (which would create a circular dependency).
+# this module's MODULE.bazel). Provides the xcb-util-image and
+# xcb-util-renderutil headers that xcb-util-cursor #includes — neither
+# upstream package is on BCR, so @libxcb (which only covers libxcb
+# proper) doesn't supply them. libxcb-proper headers come from @libxcb.
 cc_library(
     name = "xcb_hdrs",
-    hdrs = glob(["xcb/*.h"]),
+    hdrs = [
+        "xcb/xcb_image.h",
+        "xcb/xcb_renderutil.h",
+    ],
     includes = ["."],
     strip_include_prefix = ".",
     visibility = ["//visibility:public"],
-)
-
-# xcb-util-cursor 0.1.5 built from source via @xcb_util_cursor (declared
-# in this module's MODULE.bazel). Replaces the system-provided
-# libxcb-cursor.so.0 cc_import that used to live here.
-alias(
-    name = "xcb_cursor",
-    actual = "@xcb_util_cursor//:cursor",
 )
 
 cc_import(
@@ -108,7 +104,7 @@ cc_library(
     deps = select({
         "@platforms//cpu:aarch64": [],
         "//conditions:default": [
-            ":xcb_cursor",
+            "@xcb_util_cursor//:cursor",
             ":xcb_icccm_ifso",
             ":xcb_ifso",
             ":xcb_image_ifso",

--- a/interface_libs/xcb/xcb_util_cursor.BUILD
+++ b/interface_libs/xcb/xcb_util_cursor.BUILD
@@ -1,0 +1,30 @@
+# BUILD overlay for the @xcb_util_cursor http_archive declared in
+# qt-bazel's MODULE.bazel. Builds xcb-util-cursor 0.1.5 as a static
+# cc_library so the Qt xcb platform plugin doesn't dlopen
+# libxcb-cursor.so.0 from the host.
+
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "cursor",
+    srcs = [
+        "cursor/cursor.c",
+        "cursor/cursor.h",
+        "cursor/load_cursor.c",
+        "cursor/parse_cursor_file.c",
+        "cursor/shape_to_id.c",
+    ],
+    hdrs = ["cursor/xcb_cursor.h"],
+    copts = [
+        # asprintf() is a GNU extension; glibc gates it behind _GNU_SOURCE.
+        "-D_GNU_SOURCE",
+        "-DXCURSORPATH='\"~/.icons:/usr/share/icons:/usr/share/pixmaps:/usr/X11R6/lib/X11/icons\"'",
+    ],
+    include_prefix = "xcb",
+    strip_include_prefix = "cursor",
+    visibility = ["@qt-bazel//interface_libs/xcb:__pkg__"],
+    deps = [
+        "@libxcb",
+        "@qt-bazel//interface_libs/xcb:xcb_hdrs",
+    ],
+)


### PR DESCRIPTION
## Summary

`interface_libs/xcb:xcb` currently dlopens `libxcb-cursor.so.0` from
the host at runtime via a `system_provided` `cc_import`. That makes
any consumer of qt-bazel's Qt xcb platform plugin require
apt-installing `libxcb-cursor0` separately, which was flagged as a
blocker for making GUI the default Bazel build in
[The-OpenROAD-Project/OpenROAD#8532](https://github.com/The-OpenROAD-Project/OpenROAD/pull/8532).

Replace the `cc_import` with a static `cc_library` compiled from
`xcb-util-cursor 0.1.5`, fetched as an `http_archive` declared in
this module's `MODULE.bazel` (sha256-verified, source from
`xorg.freedesktop.org`).

## Why upstream and not a downstream patch

This was originally implemented as a downstream patch in
[The-OpenROAD-Project/bazel-orfs](https://github.com/The-OpenROAD-Project/bazel-orfs/blob/master/patches/qt-bazel-xcb-cursor-from-source.patch)
(and ported as a \`patch_cmds\`/\`patches\` block in OpenROAD#10412),
but @QuantamHD's [review feedback](https://github.com/The-OpenROAD-Project/OpenROAD/pull/10412#issuecomment-4437770861)
on that approach was *"Can you send this to the upstream repo
instead of patching it"* — exactly right, since once it lives here,
every consumer of qt-bazel gets the fix for free with no
downstream churn.

## How

- \`MODULE.bazel\` declares an \`http_archive\` named \`xcb_util_cursor\`
  pointing at the upstream 0.1.5 tarball, sha256-verified. Uses
  the idiomatic \`use_repo_rule(...)\` form so no curl-in-patch_cmds
  or shell tools are involved.
- \`interface_libs/xcb/xcb_util_cursor.BUILD\` is the build overlay
  for that archive: a single \`cc_library(name = "cursor", ...)\`
  that compiles \`cursor.c / load_cursor.c / parse_cursor_file.c /
  shape_to_id.c\` with \`-D_GNU_SOURCE\` (for \`asprintf\`) and
  \`-DXCURSORPATH=...\` (matching the upstream autotools default).
  Depends on \`@libxcb\` (already a \`bazel_dep\` of this module) and
  on \`:xcb_hdrs\` for the xcb-util headers the source needs.
- \`interface_libs/xcb/BUILD.bazel\`:
  - Drops \`cc_import(name = "xcb_cursor_ifso", system_provided = True)\`.
  - Adds a \`cc_library(name = "xcb_hdrs", hdrs = glob(["xcb/*.h"]))\`
    target (public visibility) so \`@xcb_util_cursor//:cursor\` can
    consume the xcb-util headers without pulling in the full \`:xcb\`
    target (which would be circular).
  - Adds \`alias(name = "xcb_cursor", actual = "@xcb_util_cursor//:cursor")\`
    so the existing \`:xcb\` deps list stays readable.
  - Rewires the \`:xcb\` \`select()\` to depend on \`:xcb_cursor\` instead
    of \`:xcb_cursor_ifso\`.

\`xcb-util-cursor\` is not on BCR, so we can't reduce this to a
\`bazel_dep\`.

## Test plan

- [ ] \`bazelisk build //...\` inside this repo still works.
- [ ] Consumer (\`The-OpenROAD-Project/OpenROAD\` at
      \`--//:platform=gui //:openroad\` or \`//:openroad-qt\`) builds
      and links successfully.
- [ ] \`readelf -d bazel-bin/openroad | grep -i cursor\` returns
      nothing on the consumer side — \`libxcb-cursor.so.0\` is no
      longer in \`DT_NEEDED\`.
- [ ] Launching that consumer binary with \`-gui\` on a host that
      does not have \`libxcb-cursor0\` installed succeeds (no more
      \`error while loading shared libraries: libxcb-cursor.so.0\`).

## Downstream follow-up

\`The-OpenROAD-Project/OpenROAD#10412\` and \`#10413\` will be
simplified to just bump qt-bazel's pinned commit once this lands.