### PR TITLE
moc: collect compilation_context.external_includes

### DIFF
--- a/qt_tools.bzl
+++ b/qt_tools.bzl
@@ -25,6 +25,11 @@ def _moc_impl(ctx):
                 target[CcInfo].compilation_context.includes,
                 target[CcInfo].compilation_context.quote_includes,
                 target[CcInfo].compilation_context.system_includes,
+                # external_includes holds directories into external repos when
+                # the external_include_paths toolchain feature is enabled; those
+                # dirs are moved out of includes/quote_includes, so moc must
+                # collect them too or it loses Qt's own header search paths.
+                target[CcInfo].compilation_context.external_includes,
             ]
             defines.append(target[CcInfo].compilation_context.defines)
 


### PR DESCRIPTION
When the external_include_paths toolchain feature is enabled, Bazel moves include directories that point into external repos out of includes/ quote_includes and into the external_includes set (emitted as -isystem for the compiler). The moc rule only collected includes/quote_includes/ system_includes, so with the feature on it lost Qt's own header search paths and moc failed to parse Qt headers, e.g.:

  qtextimagehandler_p.h: error: Undefined interface
  qfilesystemmodel.h: error: Parse error at "QT7_ONLY"

Also gather external_includes so moc keeps its -I paths regardless of the feature.